### PR TITLE
chore: drop EOL PHP 8.2, test against 8.3–8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.9"
     },
     "require-dev": {


### PR DESCRIPTION
Removes the deprecated PHP 8.2 from CI and bumps the minimum supported version.

## Changes
- `composer.json`: `php` requirement `^8.2` → `^8.3` (8.2 reaches EOL end of 2026)
- `run-tests.yml`: test matrix `[8.4, 8.3, 8.2]` → `[8.5, 8.4, 8.3]`

## Verified locally (PHP 8.5.7)
- ✅ PHPStan: no errors
- ✅ Pest: 28 passed (37 assertions)